### PR TITLE
Extend users and database module with additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ mysql_bind_address: '0.0.0.0'
 mysql_datadir: /var/lib/mysql
 mysql_socket: *default value depends on OS*
 mysql_pid_file: *default value depends on OS*
+
+mysql_login_host: ""
+mysql_login_user: ""
+mysql_login_password: ""
+mysql_ca_cert: ""
 ```
 
 Default MySQL connection configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,16 @@ mysql_bind_address: '0.0.0.0'
 mysql_skip_name_resolve: false
 mysql_datadir: /var/lib/mysql
 mysql_sql_mode: ~
+
+# Host running the database
+mysql_login_host: ""
+# The username and password used to authenticate with
+mysql_login_user: ""
+mysql_login_password: ""
+# The path to a Certificate Authority (CA) certificate.
+# This option, if used, must specify the same certificate as used by the server
+mysql_ca_cert: ""
+
 # The following variables have a default value depending on operating system.
 # mysql_pid_file: /var/run/mysqld/mysqld.pid
 # mysql_socket: /var/lib/mysql/mysql.sock

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart mysql
+- name: Restart mysql
   ansible.builtin.service:
     name: "{{ mysql_daemon }}"
     state: restarted

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,7 +13,7 @@
     group: root
     mode: 0644
     force: "{{ overwrite_global_mycnf }}"
-  notify: restart mysql
+  notify: Restart mysql
 
 - name: Verify mysql include directory exists.
   ansible.builtin.file:
@@ -33,7 +33,7 @@
     mode: 0644
     force: "{{ item.force | default(False) }}"
   with_items: "{{ mysql_config_include_files }}"
-  notify: restart mysql
+  notify: Restart mysql
 
 - name: Create slow query log file (if configured).
   ansible.builtin.command: "touch {{ mysql_slow_query_log_file }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,9 +1,13 @@
 ---
 - name: Ensure MySQL databases are present.
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "{{ item.state | default('present') }}"
     target: "{{ item.target | default(omit) }}"
+    login_user: "{{ mysql_login_user | default(omit) }}"
+    login_password: "{{ mysql_login_password | default(omit) }}"
+    login_host: "{{ mysql_login_host | default(omit) }}"
+    ca_cert: "{{ mysql_ca_cert | default(omit) }}"
   with_items: "{{ mysql_databases }}"

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure replication user exists on master.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ mysql_replication_user.name }}"
     host: "{{ mysql_replication_user.host | default('%') }}"
     password: "{{ mysql_replication_user.password }}"
@@ -14,7 +14,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Check slave replication status.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: getreplica
     login_user: "{{ mysql_root_username }}"
     login_password: "{{ mysql_root_password }}"
@@ -28,7 +28,7 @@
 
 # https://github.com/ansible/ansible/issues/82264
 - name: Check master replication status.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: getprimary
   delegate_to: "{{ mysql_replication_master_inventory_host | default(omit, true) }}"
   register: master
@@ -39,7 +39,7 @@
   tags: ['skip_ansible_galaxy']
 
 - name: Configure replication on the slave.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: changeprimary
     master_host: "{{ mysql_replication_master }}"
     master_user: "{{ mysql_replication_user.name }}"
@@ -55,7 +55,7 @@
     - (mysql_replication_master | length) > 0
 
 - name: Start replication.
-  mysql_replication:
+  community.mysql.mysql_replication:
     mode: startreplica
   when:
     - (slave.Is_Slave is defined and slave.Is_Slave) or (slave.Is_Replica is defined and slave.Is_Replica) or (slave.Is_Slave is not defined and slave.Is_Replica is not defined and slave is failed)

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure default user is present.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ mysql_user_name }}"
     host: 'localhost'
     password: "{{ mysql_user_password }}"
@@ -81,13 +81,13 @@
   check_mode: false
 
 - name: Remove anonymous MySQL users.
-  mysql_user:
+  community.mysql.mysql_user:
     name: ""
     host: "{{ item }}"
     state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Remove MySQL test database.
-  mysql_db:
+  community.mysql.mysql_db:
     name: 'test'
     state: absent

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,8 +6,8 @@
 
 - name: Update apt cache if MySQL is not yet installed.
   ansible.builtin.apt:
-    update_cache: yes
-  changed_when: False
+    update_cache: true
+  changed_when: false
   when: not mysql_installed.stat.exists
 
 - name: Ensure MySQL Python libraries are installed.

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure MySQL users are present.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"
@@ -8,5 +8,9 @@
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
+    login_user: "{{ mysql_login_user | default(omit) }}"
+    login_password: "{{ mysql_login_password | default(omit) }}"
+    login_host: "{{ mysql_login_host | default(omit) }}"
+    ca_cert: "{{ mysql_ca_cert | default(omit) }}"
   with_items: "{{ mysql_users }}"
   no_log: "{{ mysql_hide_passwords }}"


### PR DESCRIPTION
- Add additional config options, like
  - login_user
  - login_host
  - login_password
  - ca_certificate

This also allows using this role for configuring users/databases for SaaS offerings, like Azure Database for MySQL. E.g.

```yaml
- hosts: localhost
  vars:
    mysql_login_host: myazuredb.azure.net
    mysql_login_user: rootuser
    mysql_login_password: secret
    mysql_ca_cert: path/to/my/cert.pem
  tasks:
    - include_role:
        name: ansible-role-mysql
        tasks_from: "{{ item }}"
      loop:
        - users
        - databases
```